### PR TITLE
fix `body.gmail_message` for non- container MIME messages

### DIFF
--- a/R/gmailr.R
+++ b/R/gmailr.R
@@ -83,28 +83,32 @@ body <- function(x, ...) UseMethod("body")
 #' @rdname body
 #' @export
 body.gmail_message <- function(x, type="text/plain", collapse = FALSE, ...){
-  if(is.null(type)){
-    good_parts <- TRUE
+  if(!is.null(x$payload$parts)) {
+    if(is.null(type)){
+      good_parts <- TRUE
+    }
+    else {
+      good_parts <- vapply(x$payload$parts, FUN.VALUE=logical(1),
+        function(part) {
+          any(
+            vapply(part$headers, FUN.VALUE=logical(1),
+              function(header) {
+                tolower(header$name) %==% "content-type" &&
+                  grepl(type, header$value, ignore.case=TRUE)
+              })
+            )
+        })
+    }
+
+    res <-
+      lapply(x$payload$parts[good_parts],
+        function(x){
+            base64url_decode_to_char(x$body$data)
+        })
   }
   else {
-    good_parts <- vapply(x$payload$parts, FUN.VALUE=logical(1),
-      function(part) {
-        any(
-          vapply(part$headers, FUN.VALUE=logical(1),
-            function(header) {
-              tolower(header$name) %==% "content-type" &&
-                grepl(type, header$value, ignore.case=TRUE)
-            })
-          )
-      })
+    res = gmailr:::base64url_decode_to_char(x$payload$body$data)
   }
-
-  res <-
-    lapply(x$payload$parts[good_parts],
-      function(x){
-          base64url_decode_to_char(x$body$data)
-      })
-
   if(collapse){
     paste0(collapse="\n", res)
   }


### PR DESCRIPTION
Currently, `body.gmail_message` only works with container MIME messages. In my application about 80% of all messages are non- container MIME so that `body` just returns an empty string `""`. For non- container MIME messages, `x$payload$parts` is empty (`NULL` in R) and `x$body$data` contains all the data. The [documentation](https://developers.google.com/gmail/api/v1/reference/users/messages) of the Gmail API mentions this (see `payload.parts[]` and `payload.body`). My changes fix this problem. It might also apply to other functions such as `body.gmail_draft`.