### PR TITLE
FIX page_token feature about messages, threads

### DIFF
--- a/R/message.R
+++ b/R/message.R
@@ -24,7 +24,6 @@ message <- function(id = ? is_string,
 #' @export
 #' @param search query to use, same format as gmail search box.
 #' @param num_results the number of results to return.
-#' @param page_token retrieve a specific page of results
 #' @param label_ids restrict search to given labels
 #' @param include_spam_trash boolean whether to include the spam and trash folders in the search
 #' @inheritParams thread
@@ -38,10 +37,9 @@ messages <- function(search = NULL ? nullable(is_string)(search),
   num_results = NULL ? nullable(is_number)(num_results),
   label_ids = NULL ? nullable(is_strings)(label_ids),
   include_spam_trash = NULL ? nullable(is_boolean)(include_spam_trash),
-  page_token = NULL ? nullable(is_string)(page_token),
   user_id = "me" ? is_string) {
 
-  page_and_trim("messages", user_id, num_results, search, page_token, label_ids, include_spam_trash)
+  page_and_trim("messages", user_id, num_results, search, label_ids, include_spam_trash)
 }
 
 #' Send a single message to the trash

--- a/R/thread.R
+++ b/R/thread.R
@@ -10,8 +10,8 @@
 #'
 #' first_10_threads = threads(10)
 #' }
-threads <- function(search = NULL, num_results = NULL, page_token = NULL, label_ids = NULL, include_spam_trash = NULL, user_id = "me"){
-  page_and_trim("threads", user_id, num_results, search, page_token, label_ids, include_spam_trash)
+threads <- function(search = NULL, num_results = NULL, label_ids = NULL, include_spam_trash = NULL, user_id = "me"){
+  page_and_trim("threads", user_id, num_results, search, label_ids, include_spam_trash)
 }
 
 #' Get a single thread

--- a/R/utils.R
+++ b/R/utils.R
@@ -48,9 +48,9 @@ dots <- function (...) { eval(substitute(alist(...))) }
 page_and_trim <- function(type, user_id, num_results, ...){
 
   num_results <- num_results %||% 100
-  itr <- function(...){
+  itr <- function(..., page_token = NULL){
     req <- GET(gmail_path(user_id, type),
-             query = not_null(rename(...)), config(token = get_token()))
+             query = not_null(rename(..., page_token = page_token)), config(token=get_token()))
     stop_for_status(req)
     content(req, "parsed")
   }
@@ -78,7 +78,8 @@ page_and_trim <- function(type, user_id, num_results, ...){
   res <- itr(...)
   all_results <- list(res)
   while(sum(counts(all_results)) < num_results && !is.null(res[["nextPageToken"]])){
-    res <- itr(...)
+    pageToken = res[["nextPageToken"]]
+    res <- itr(page_token = pageToken, ...)
     all_results[[length(all_results) + 1]] <- res
   }
   structure(trim(all_results, num_results), class=paste0("gmail_", type))

--- a/man/messages.Rd
+++ b/man/messages.Rd
@@ -5,7 +5,7 @@
 \title{Get a list of messages}
 \usage{
 messages(search = NULL, num_results = NULL, label_ids = NULL,
-  include_spam_trash = NULL, page_token = NULL, user_id = "me")
+  include_spam_trash = NULL, user_id = "me")
 }
 \arguments{
 \item{search}{query to use, same format as gmail search box.}
@@ -15,8 +15,6 @@ messages(search = NULL, num_results = NULL, label_ids = NULL,
 \item{label_ids}{restrict search to given labels}
 
 \item{include_spam_trash}{boolean whether to include the spam and trash folders in the search}
-
-\item{page_token}{retrieve a specific page of results}
 
 \item{user_id}{gmail user_id to access, special value of 'me' indicates the authenticated user.}
 }

--- a/man/threads.Rd
+++ b/man/threads.Rd
@@ -4,15 +4,13 @@
 \alias{threads}
 \title{Get a list of threads}
 \usage{
-threads(search = NULL, num_results = NULL, page_token = NULL,
-  label_ids = NULL, include_spam_trash = NULL, user_id = "me")
+threads(search = NULL, num_results = NULL, label_ids = NULL,
+  include_spam_trash = NULL, user_id = "me")
 }
 \arguments{
 \item{search}{query to use, same format as gmail search box.}
 
 \item{num_results}{the number of results to return.}
-
-\item{page_token}{retrieve a specific page of results}
 
 \item{label_ids}{restrict search to given labels}
 


### PR DESCRIPTION
page_token parameter changed to be used only in page_and_trim
internaly, and not accessed externally (messages, threads)

Paging seems to have a bug. This code can test it and should return 200, but now returns 100.
```
# should return 200
length(unique(id(messages(num_results = 200)))) 
```
This response to #19 
