### PR TITLE
allow multiple auth scopes

### DIFF
--- a/R/gmailr.R
+++ b/R/gmailr.R
@@ -74,12 +74,11 @@ gmail_auth <- function(scope=c("read_only", "modify", "compose", "full"),
   }
   myapp <- oauth_app("google", id, secret)
 
-  scope <- switch(match.arg(scope),
-                 read_only = "https://www.googleapis.com/auth/gmail.readonly",
-                 modify = "https://www.googleapis.com/auth/gmail.modify",
-                 compose = "https://www.googleapis.com/auth/gmail.compose",
-                 full = "https://mail.google.com/"
-                 )
+  scope_urls <- c(read_only = "https://www.googleapis.com/auth/gmail.readonly",
+                  modify = "https://www.googleapis.com/auth/gmail.modify",
+                  compose = "https://www.googleapis.com/auth/gmail.compose",
+                  full = "https://mail.google.com/")  
+  scope <- scope_urls[match.arg(scope, several.ok=TRUE)]
 
   the$token <- oauth2.0_token(oauth_endpoints("google"), myapp, scope = scope)
 }


### PR DESCRIPTION
Sometimes we need to specify multiple auth scopes, like "read_only" and "compose". The gmail docs made it sound like compose implies read_only, but that does not appear to be true, in practice.