### PR TITLE
Improve error message

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -10,3 +10,5 @@ TODO.md
 ^.*gz$
 ^travis-tool\.sh$
 ^\.lintr$
+^.*\.Rproj$
+^\.Rproj\.user$

--- a/R/gmailr.R
+++ b/R/gmailr.R
@@ -77,7 +77,7 @@ gmail_auth <- function(scope=c("read_only", "modify", "compose", "full"),
   scope_urls <- c(read_only = "https://www.googleapis.com/auth/gmail.readonly",
                   modify = "https://www.googleapis.com/auth/gmail.modify",
                   compose = "https://www.googleapis.com/auth/gmail.compose",
-                  full = "https://mail.google.com/")  
+                  full = "https://mail.google.com/")
   scope <- scope_urls[match.arg(scope, several.ok=TRUE)]
 
   the$token <- oauth2.0_token(oauth_endpoints("google"), myapp, scope = scope)
@@ -334,7 +334,7 @@ gmailr_query <- function(fun, location, user_id, class = NULL, ...) {
         response = response,
         message = paste0("Gmail API error: ", status_code(response), "\n  ", result$error$message, "\n")),
         class = c("condition", "error", "gmailr_error"))
-    stop(cond, call. = FALSE)
+    stop(cond)
   }
 
   if (!is.null(class)) {


### PR DESCRIPTION
Having spent some quality time with gmailr error messages, I was motivated to clear up this warning.

BEFORE:
```
> send_message(text_msg)
 Show Traceback
 
 Rerun with Debug
 Error in gmailr_POST(c("messages", "send"), user_id, class = "gmail_message",  : 
  Gmail API error: 400
  Mail service not enabled In addition: Warning message:
In stop(cond, call. = FALSE) : additional arguments ignored in stop()
```

AFTER:
```
> send_message(text_msg)
 Show Traceback
 
 Rerun with Debug
 Error in gmailr_POST(c("messages", "send"), user_id, class = "gmail_message",  : 
  Gmail API error: 400
  Mail service not enabled 
```