### PR TITLE
Draft fixes

### DIFF
--- a/R/draft.R
+++ b/R/draft.R
@@ -47,7 +47,6 @@ drafts <- function(num_results = NULL, page_token = NULL, user_id = "me") {
 #' Create a draft from a mime message
 #'
 #' @param mail mime mail message created by mime
-#' @param type the type of upload to perform
 #' @inheritParams message
 #' @references \url{https://developers.google.com/gmail/api/v1/reference/users/drafts/create}
 #' @export

--- a/R/draft.R
+++ b/R/draft.R
@@ -57,19 +57,15 @@ drafts <- function(num_results = NULL, page_token = NULL, user_id = "me") {
 #'                           Subject="hello", "how are you doing?"))
 #' }
 create_draft <- function(mail,
-                         user_id = "me",
-                         type = c("multipart",
-                                "media",
-                                "resumable")) {
+                         user_id = "me") {
   mail <- as.character(mail)
   stopifnot(is_string(user_id))
-  type <- match.arg(type)
   res <- gmailr_POST("drafts", user_id, class = "gmail_draft",
-              query = list(uploadType=type),
-              body = jsonlite::toJSON(auto_unbox=TRUE,
-                list(message=list(raw=base64url_encode(mail)))),
-              add_headers("Content-Type" = "application/json"))
-
+              query = list(uploadType="media"),
+              body = mail,
+              add_headers("Content-Type" = "message/rfc822"),
+              upload=TRUE)
+  
   # This is labeled as a message but is really a thread
   class(res$message) <- c("gmail_thread", "list")
   res

--- a/R/gmailr.R
+++ b/R/gmailr.R
@@ -320,8 +320,10 @@ print.gmail_drafts <- function(x, ...){
 
 the$last_response <- list()
 
-gmailr_query <- function(fun, location, user_id, class = NULL, ...) {
-  response <- fun(gmail_path(user_id, location),
+gmailr_query <- function(fun, location, user_id, class = NULL, upload = FALSE,
+                         ...) {
+  path_fun <- if (upload) gmail_upload_path else gmail_path
+  response <- fun(path_fun(user_id, location),
              config(token = get_token()),
               ...)
   result <- content(response, "parsed")

--- a/man/create_draft.Rd
+++ b/man/create_draft.Rd
@@ -4,15 +4,12 @@
 \alias{create_draft}
 \title{Create a draft from a mime message}
 \usage{
-create_draft(mail, user_id = "me", type = c("multipart", "media",
-  "resumable"))
+create_draft(mail, user_id = "me")
 }
 \arguments{
 \item{mail}{mime mail message created by mime}
 
 \item{user_id}{gmail user_id to access, special value of 'me' indicates the authenticated user.}
-
-\item{type}{the type of upload to perform}
 }
 \description{
 Create a draft from a mime message


### PR DESCRIPTION
Looks like there have been some changes in draft uploading. This resolves #72 (and more). I didn't see a point in `create_draft()` having a `type` parameter, because the code basically relies on it being of type "media". The upload format is much simpler now.