### PR TITLE
Move upload after the ...

### DIFF
--- a/R/gmailr.R
+++ b/R/gmailr.R
@@ -320,12 +320,11 @@ print.gmail_drafts <- function(x, ...){
 
 the$last_response <- list()
 
-gmailr_query <- function(fun, location, user_id, class = NULL, upload = FALSE,
-                         ...) {
+gmailr_query <- function(fun, location, user_id, class = NULL, ...,
+  upload = FALSE) {
   path_fun <- if (upload) gmail_upload_path else gmail_path
   response <- fun(path_fun(user_id, location),
-             config(token = get_token()),
-              ...)
+             config(token = get_token()), ...)
   result <- content(response, "parsed")
 
   the$last_response <- response


### PR DESCRIPTION
Fixes `send_message()`, which calls gmail_POST with 5 arguments, the
last of which should be used in `...`, not upload.